### PR TITLE
Add circular shape option

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,14 @@ See [Options](#options).
   If width is too small to contain the qr symbol, this option will be ignored.<br>
   Takes precedence over `scale`.
 
+##### `shape`
+  Type: `String`<br>
+  Default: `square`<br>
+
+  Shape of the final QR code. Possible values are `square` or `circle`.
+  When set to `circle`, extra modules are added to fill the empty corners and
+  produce a circular appearance.
+
 ##### `color.dark`
 Type: `String`<br>
 Default: `#000000ff`

--- a/lib/renderer/svg-tag.js
+++ b/lib/renderer/svg-tag.js
@@ -58,6 +58,12 @@ exports.render = function render (qrData, options, cb) {
   const data = qrData.modules.data
   const qrcodesize = size + opts.margin * 2
 
+  const circle = opts.shape === 'circle'
+    ? '<circle ' + getColorAttrib(opts.color.dark, 'fill') +
+      ' cx="' + qrcodesize / 2 + '" cy="' + qrcodesize / 2 +
+      '" r="' + qrcodesize / 2 + '"/>'
+    : ''
+
   const bg = !opts.color.light.a
     ? ''
     : '<path ' + getColorAttrib(opts.color.light, 'fill') +
@@ -71,7 +77,8 @@ exports.render = function render (qrData, options, cb) {
 
   const width = !opts.width ? '' : 'width="' + opts.width + '" height="' + opts.width + '" '
 
-  const svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox + ' shape-rendering="crispEdges">' + bg + path + '</svg>\n'
+  const svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox +
+    ' shape-rendering="crispEdges">' + circle + bg + path + '</svg>\n'
 
   if (typeof cb === 'function') {
     cb(null, svgTag)

--- a/lib/renderer/utils.js
+++ b/lib/renderer/utils.js
@@ -45,6 +45,7 @@ exports.getOptions = function getOptions (options) {
 
   const width = options.width && options.width >= 21 ? options.width : undefined
   const scale = options.scale || 4
+  const shape = options.shape === 'circle' ? 'circle' : 'square'
 
   return {
     width: width,
@@ -55,7 +56,8 @@ exports.getOptions = function getOptions (options) {
       light: hex2rgba(options.color.light || '#ffffffff')
     },
     type: options.type,
-    rendererOpts: options.rendererOpts || {}
+    rendererOpts: options.rendererOpts || {},
+    shape: shape
   }
 }
 
@@ -77,6 +79,8 @@ exports.qrToImageData = function qrToImageData (imgData, qr, opts) {
   const symbolSize = Math.floor((size + opts.margin * 2) * scale)
   const scaledMargin = opts.margin * scale
   const palette = [opts.color.light, opts.color.dark]
+  const radius = symbolSize / 2
+  const center = radius - 0.5
 
   for (let i = 0; i < symbolSize; i++) {
     for (let j = 0; j < symbolSize; j++) {
@@ -88,6 +92,14 @@ exports.qrToImageData = function qrToImageData (imgData, qr, opts) {
         const iSrc = Math.floor((i - scaledMargin) / scale)
         const jSrc = Math.floor((j - scaledMargin) / scale)
         pxColor = palette[data[iSrc * size + jSrc] ? 1 : 0]
+      }
+
+      if (opts.shape === 'circle') {
+        const dx = j - center
+        const dy = i - center
+        if (Math.sqrt(dx * dx + dy * dy) > radius) {
+          pxColor = opts.color.dark
+        }
       }
 
       imgData[posDst++] = pxColor.r


### PR DESCRIPTION
## Summary
- support new `shape` option for renderers
- allow circular QR code output by filling corners with dark pixels
- document the new option in README

## Testing
- `npm test` *(fails: standard not found)*