### PR TITLE
Add dotted-circle shape option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Renderer options:
   -w, --width       Image width (px)                                    [number]
   -s, --scale       Scale factor                                        [number]
   -q, --qzone       Quiet zone size                                     [number]
+  -p, --shape       QR code shape            [choices: "square", "circle"]
   -l, --lightcolor  Light RGBA hex color
   -d, --darkcolor   Dark RGBA hex color
   --small  Output smaller QR code to terminal                          [boolean]
@@ -72,6 +73,7 @@ Examples:
   qrcode "some text"                    Draw in terminal window
   qrcode -o out.png "some text"         Save as png image
   qrcode -d F00 -o out.png "some text"  Use red as foreground color
+  qrcode -p circle -o out.png "some text"  Generate circular QR code
 ```
 If not specified, output type is guessed from file extension.<br>
 Recognized extensions are `png`, `svg` and `txt`.
@@ -738,6 +740,15 @@ See [Options](#options).
   Forces a specific width for the output image.<br>
   If width is too small to contain the qr symbol, this option will be ignored.<br>
   Takes precedence over `scale`.
+
+##### `shape`
+  Type: `String`<br>
+  Default: `square`<br>
+
+Shape of the final QR code. Possible values are `square` or `circle`.
+When set to `circle`, random decoy modules fill the empty corners so the
+overall symbol appears circular. These extra dots do not alter the encoded
+data.
 
 ##### `color.dark`
 Type: `String`<br>

--- a/bin/qrcode
+++ b/bin/qrcode
@@ -39,7 +39,8 @@ function parseOptions (args) {
     color: {
       light: args.lightcolor,
       dark: args.darkcolor
-    }
+    },
+    shape: args.shape
   }
 }
 
@@ -109,6 +110,12 @@ var argv = yargs
     description: 'Quiet zone size',
     group: 'Renderer options:',
     type: 'number'
+  })
+  .option('p', {
+    alias: 'shape',
+    description: 'QR code shape',
+    choices: ['square', 'circle'],
+    group: 'Renderer options:'
   })
   .option('l', {
     alias: 'lightcolor',

--- a/examples/circle.js
+++ b/examples/circle.js
@@ -1,0 +1,6 @@
+var QRCode = require('../lib')
+
+QRCode.toFile('circle.png', 'example text', { shape: 'circle' }, function (err) {
+  if (err) throw err
+  console.log('saved circle.png')
+})

--- a/lib/renderer/svg-tag.js
+++ b/lib/renderer/svg-tag.js
@@ -58,6 +58,23 @@ exports.render = function render (qrData, options, cb) {
   const data = qrData.modules.data
   const qrcodesize = size + opts.margin * 2
 
+  let decoys = ''
+  if (opts.shape === 'circle') {
+    const modules = size + opts.margin * 2
+    const radius = modules / 2
+    const center = radius - 0.5
+    for (let r = 0; r < modules; r++) {
+      for (let c = 0; c < modules; c++) {
+        const dx = c - center
+        const dy = r - center
+        if (Math.sqrt(dx * dx + dy * dy) > radius && Utils.isDecoy(r, c)) {
+          decoys += '<rect ' + getColorAttrib(opts.color.dark, 'fill') +
+            ' x="' + c + '" y="' + r + '" width="1" height="1"/>'
+        }
+      }
+    }
+  }
+
   const bg = !opts.color.light.a
     ? ''
     : '<path ' + getColorAttrib(opts.color.light, 'fill') +
@@ -71,7 +88,8 @@ exports.render = function render (qrData, options, cb) {
 
   const width = !opts.width ? '' : 'width="' + opts.width + '" height="' + opts.width + '" '
 
-  const svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox + ' shape-rendering="crispEdges">' + bg + path + '</svg>\n'
+  const svgTag = '<svg xmlns="http://www.w3.org/2000/svg" ' + width + viewBox +
+    ' shape-rendering="crispEdges">' + decoys + bg + path + '</svg>\n'
 
   if (typeof cb === 'function') {
     cb(null, svgTag)

--- a/lib/renderer/utils.js
+++ b/lib/renderer/utils.js
@@ -33,6 +33,12 @@ function hex2rgba (hex) {
   }
 }
 
+function isDecoy (i, j) {
+  return ((i * 31 + j * 17 + 13) % 5) === 0
+}
+
+exports.isDecoy = isDecoy
+
 exports.getOptions = function getOptions (options) {
   if (!options) options = {}
   if (!options.color) options.color = {}
@@ -45,6 +51,7 @@ exports.getOptions = function getOptions (options) {
 
   const width = options.width && options.width >= 21 ? options.width : undefined
   const scale = options.scale || 4
+  const shape = options.shape === 'circle' ? 'circle' : 'square'
 
   return {
     width: width,
@@ -55,7 +62,8 @@ exports.getOptions = function getOptions (options) {
       light: hex2rgba(options.color.light || '#ffffffff')
     },
     type: options.type,
-    rendererOpts: options.rendererOpts || {}
+    rendererOpts: options.rendererOpts || {},
+    shape: shape
   }
 }
 
@@ -77,6 +85,9 @@ exports.qrToImageData = function qrToImageData (imgData, qr, opts) {
   const symbolSize = Math.floor((size + opts.margin * 2) * scale)
   const scaledMargin = opts.margin * scale
   const palette = [opts.color.light, opts.color.dark]
+  const modules = size + opts.margin * 2
+  const radiusModule = modules / 2
+  const centerModule = radiusModule - 0.5
 
   for (let i = 0; i < symbolSize; i++) {
     for (let j = 0; j < symbolSize; j++) {
@@ -88,6 +99,16 @@ exports.qrToImageData = function qrToImageData (imgData, qr, opts) {
         const iSrc = Math.floor((i - scaledMargin) / scale)
         const jSrc = Math.floor((j - scaledMargin) / scale)
         pxColor = palette[data[iSrc * size + jSrc] ? 1 : 0]
+      }
+
+      if (opts.shape === 'circle') {
+        const iMod = Math.floor(i / scale)
+        const jMod = Math.floor(j / scale)
+        const dx = jMod - centerModule
+        const dy = iMod - centerModule
+        if (Math.sqrt(dx * dx + dy * dy) > radiusModule && isDecoy(iMod, jMod)) {
+          pxColor = opts.color.dark
+        }
       }
 
       imgData[posDst++] = pxColor.r


### PR DESCRIPTION
## Summary
- implement decoy-based circle rendering
- export helper for decoy dots
- support `--shape` CLI flag
- document `shape` option and new CLI flag
- add example for circular output

## Testing
- `npm test` *(fails: standard not found)*
